### PR TITLE
avoid 'undefined index warning' and explicitly bracket control statements

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -408,8 +408,13 @@ $batcache->keys = array(
 	'extra' => $batcache->unique
 );
 
-if ( $batcache->is_ssl() )
+if ( $batcache->is_ssl() ) {
 	$batcache->keys['ssl'] = true;
+}
+else {
+	$batcache->keys['ssl'] = false;
+}
+	
 
 // Recreate the permalink from the URL
 $batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );


### PR DESCRIPTION
This PR resolves an "Undefined index: ssl" notice