### PR TITLE
Remove 'wordpress' from cookie exemption

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -444,7 +444,7 @@ if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {
 		        $bc_has_cookie_excempt = true;
 	        }
         }
-        if ( false === $bc_has_no_skip && true === $bc_has_cookie_excempt ) {
+        if ( (false === $bc_has_no_skip && true === $bc_has_cookie_excempt) || true === $bc_has_cookie_excempt ) {
                 batcache_stats( 'batcache', 'cookie_skip' );
                 return;
         }


### PR DESCRIPTION
If there is an exempt cookie, such as `wordpress_logged_in_*`, do not cache the page.

Also removed 'wordpress' from cookie exemption list because it can also match the set noskip cookie name (i.e. `wordpress_test_cookie`).